### PR TITLE
chore: add TDD enforcement rule

### DIFF
--- a/.augment/rules/00-chipp-rs-core.md
+++ b/.augment/rules/00-chipp-rs-core.md
@@ -55,6 +55,29 @@ Before publishing to crates.io:
 - Does the documentation explain WHY, not just WHAT?
 - Will users understand error messages?
 
+## Git Workflow
+
+**NEVER commit directly to `main`**. Always use feature branches:
+
+```bash
+# 1. Create branch from main
+git checkout main && git pull
+git checkout -b <type>/issue-<number>-<description>
+
+# 2. Make changes and commit to the branch
+git add <files>
+git commit -m "<type>: <description>"
+
+# 3. Push branch and create PR
+git push -u origin <branch-name>
+# Use create-pr command or GitHub API
+```
+
+**Branch naming**: `<type>/issue-<number>-<short-description>`
+- `fix/issue-3-client-new-returns-result`
+- `feat/issue-10-add-retry-logic`
+- `chore/issue-4-tdd-enforcement-rule`
+
 ## Release Process
 
 1. **Conventional Commits**: Use `feat:`, `fix:`, `docs:`, `chore:`, etc.

--- a/.augment/rules/65-tdd-enforcement.md
+++ b/.augment/rules/65-tdd-enforcement.md
@@ -1,0 +1,123 @@
+---
+description: Enforce TDD workflow for all code changes
+globs: ["src/**/*.rs", "tests/**/*.rs", "examples/**/*.rs"]
+---
+
+# TDD Enforcement
+
+## MANDATORY WORKFLOW
+
+For ANY code change that modifies behavior:
+
+### 1. RED Phase (Write Failing Test First)
+
+- Write a test that describes the expected behavior
+- Run `just test` - tests MUST fail (or be new)
+- Commit: `test: add failing test for <feature>`
+
+### 2. GREEN Phase (Minimal Implementation)
+
+- Write the MINIMUM code to make the test pass
+- No extra features, no premature optimization
+- Run `just test` - tests MUST pass
+- Commit: `feat: implement <feature>` or `fix: resolve <bug>`
+
+### 3. REFACTOR Phase (Improve with Safety Net)
+
+- Clean up code while tests stay green
+- Apply DRY, extract functions, improve naming
+- Run `just test` after each change
+- Commit: `refactor: improve <component>`
+
+## Verification Commands
+
+```bash
+just test          # Run unit tests (fast feedback)
+just test-all      # Run all tests including doc tests
+just coverage-check # Verify ≥80% coverage threshold
+```
+
+## Test Location Conventions
+
+| Code Location | Test Location |
+|---------------|---------------|
+| `src/lib.rs` (public API) | `tests/unit/*.rs` or inline `#[cfg(test)]` |
+| `src/*.rs` (internal) | Inline `#[cfg(test)]` modules |
+| Integration scenarios | `tests/integration_test.rs` |
+| Example usage | `examples/*.rs` (verified by `cargo test --examples`) |
+
+## Test Naming Convention
+
+```rust
+#[test]
+fn test_<function>_<scenario>_<expected_result>() {
+    // ARRANGE - set up test data
+    // ACT - call the function
+    // ASSERT - verify the result
+}
+
+// Examples:
+fn test_new_valid_config_returns_ok() { ... }
+fn test_chat_empty_messages_returns_error() { ... }
+fn test_parse_stream_chunk_valid_data_extracts_content() { ... }
+```
+
+## What Requires TDD
+
+✅ **MUST use TDD**:
+- New public API methods
+- Bug fixes (write test that reproduces bug first)
+- Behavior changes to existing code
+- New error types or error conditions
+
+## Exceptions (No TDD Required)
+
+❌ **Skip TDD for**:
+- Documentation-only changes (`*.md`, rustdoc comments)
+- Configuration files (`Cargo.toml`, `justfile`, `.github/`)
+- Refactoring with existing test coverage
+- Adding new dependencies (but test their usage)
+
+## Example TDD Flow
+
+### Bug Fix Example
+
+```bash
+# 1. RED: Write test that reproduces the bug
+git add tests/unit/client_tests.rs
+git commit -m "test: add failing test for panic on invalid timeout"
+
+# 2. GREEN: Fix the bug
+git add src/lib.rs
+git commit -m "fix: handle invalid timeout gracefully"
+
+# 3. REFACTOR: Clean up if needed
+git add src/lib.rs
+git commit -m "refactor: extract timeout validation to separate function"
+```
+
+### New Feature Example
+
+```bash
+# 1. RED: Write test for new behavior
+git add tests/unit/streaming_tests.rs
+git commit -m "test: add test for retry on connection reset"
+
+# 2. GREEN: Implement the feature
+git add src/streaming.rs
+git commit -m "feat(streaming): add retry on connection reset"
+
+# 3. REFACTOR: Improve implementation
+git add src/streaming.rs
+git commit -m "refactor(streaming): extract retry logic to helper"
+```
+
+## Enforcement
+
+When assisting with code changes:
+
+1. **Before writing implementation**: Ask "Where is the failing test?"
+2. **If no test exists**: Write the test first, verify it fails
+3. **After implementation**: Run `just test` to verify green
+4. **Before PR**: Run `just coverage-check` to verify ≥80% coverage
+

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,7 +1,6 @@
 ---
 description: Create comprehensive pull requests with GitHub issue linking, conventional commit titles, and automated quality validation for chipp-rs SDK development
 argument-hint: [issue-number] [--draft] [--dry-run]
-model: sonnet
 allowed-tools: [github-api, launch-process, view, codebase-retrieval]
 ---
 


### PR DESCRIPTION
## Summary

Add TDD (Test-Driven Development) enforcement rule to `.augment/rules/` to ensure consistent test-first development practices. Also adds explicit Git workflow guidelines to prevent direct commits to main.

## Linked Issues

Closes #4

## Changes

### Added
- `.augment/rules/65-tdd-enforcement.md` - RED → GREEN → REFACTOR workflow
  - Mandatory TDD workflow for code changes
  - Verification commands using `just` recipes
  - Test location and naming conventions
  - Clear exceptions (docs, config, refactoring)
  - Example TDD flows for bugs and features

### Changed
- `.augment/rules/00-chipp-rs-core.md` - Added Git Workflow section
  - Explicit "NEVER commit directly to main" rule
  - Branch naming convention: `<type>/issue-<number>-<description>`

### Fixed
- `.claude/commands/create-pr.md` - Removed invalid `model: sonnet` line

## Quality Checks

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (11 tests)
- [x] No code changes - documentation/rules only

## Checklist

- [x] Rule follows existing `.augment/rules/` patterns
- [x] Includes verification commands
- [x] Documents exceptions clearly
- [x] Branch naming convention documented

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author