### PR TITLE
chore: add automated release workflow with changelog generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,108 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Run quality checks before release
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Run tests
+        run: cargo test --all-features
+
+      - name: Build docs
+        run: cargo doc --no-deps --all-features
+        env:
+          RUSTDOCFLAGS: -D warnings
+
+      - name: Dry-run publish
+        run: cargo publish --dry-run
+
+  # Create GitHub release and publish to crates.io
+  release:
+    needs: quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for git-cliff to see all history
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          # Check if this is a pre-release (contains hyphen like v0.1.0-alpha.1)
+          if [[ "$VERSION" == *-* ]]; then
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate changelog
+        uses: orhun/git-cliff-action@v4
+        id: git-cliff
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+        env:
+          OUTPUT: CHANGES.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: ${{ steps.git-cliff.outputs.content }}
+          prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
+          generate_release_notes: false
+
+      - name: Publish to crates.io
+        uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+


### PR DESCRIPTION
## Summary

Automates CHANGELOG.md generation and release process using GitHub Actions. When a version tag is pushed (e.g., `v0.1.0`), the workflow:

1. Runs quality checks (fmt, clippy, tests, docs, dry-run publish)
2. Generates changelog from conventional commits using git-cliff
3. Creates a GitHub Release with the changelog content
4. Publishes the crate to crates.io

## Linked Issues

Closes #1

## Changes

### Added
- `.github/workflows/release.yml` - Complete release automation workflow
  - **Quality job**: Runs fmt, clippy, tests, docs, and publish dry-run before release
  - **Release job**: Generates changelog, creates GitHub Release, publishes to crates.io
  - **Pre-release support**: Tags with `-` suffix (e.g., `v0.1.0-alpha.1`) auto-marked as prerelease

## Release Flow

```
git tag v0.1.0
git push origin v0.1.0
```

↓ Triggers workflow:

1. ✅ Quality checks pass
2. 📝 Changelog generated from commits
3. 🚀 GitHub Release created
4. 📦 Published to crates.io

## Pre-release Detection

| Tag | Prerelease |
|-----|------------|
| `v0.1.0` | ❌ Stable |
| `v0.1.0-alpha.1` | ✅ Pre-release |
| `v0.1.0-beta.2` | ✅ Pre-release |
| `v0.1.0-rc.1` | ✅ Pre-release |

## Testing

- [ ] Test with pre-release tag (e.g., `v0.1.1-alpha.1`) after merge
- [x] All tests passing (`cargo test`)
- [x] Doc tests passing (`cargo test --doc`)

## Quality Checks

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo doc --no-deps` produces no warnings
- [x] `CARGO_REGISTRY_TOKEN` secret configured

## Action Versions (December 2025)

| Action | Version |
|--------|--------|
| `orhun/git-cliff-action` | v4 (4.6.0) |
| `softprops/action-gh-release` | v2 (2.5.0) |
| `katyo/publish-crates` | v2 |

## Checklist

- [x] Code follows SDK patterns
- [x] Uses latest action versions (2025)
- [x] Pre-release detection implemented
- [x] Quality checks run before publishing

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author