### PR TITLE
docs: fix README and add docs.rs documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,8 +202,12 @@ Fix all clippy warnings before committing. If you believe a warning is a false p
 Verify docs build without warnings:
 
 ```bash
-cargo doc --no-deps
+cargo doc --no-deps --all-features
 ```
+
+Preview locally: `cargo doc --open`
+
+Documentation is automatically built on [docs.rs](https://docs.rs/chipp) when published. See the [docs.rs documentation](https://docs.rs/about) for details.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         max_retries: 3,
     };
 
-    let client = ChippClient::new(config);
+    let client = ChippClient::new(config)?;
     let mut session = ChippSession::new();
 
     let messages = vec![ChippMessage {
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```rust
 use chipp::{ChippClient, ChippConfig, ChippMessage, ChippSession, MessageRole};
 
-let client = ChippClient::new(config);
+let client = ChippClient::new(config)?;
 let mut session = ChippSession::new();
 
 let messages = vec![ChippMessage {
@@ -271,7 +271,6 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 ## Acknowledgments
 
 - Built for the [Chipp.ai](https://chipp.ai) platform
-- Originally developed as part of the [Chipp Edge Companion](https://github.com/paulbreuler/chipp-edge-companion) project
 
 ## Links
 


### PR DESCRIPTION
## Summary

Cleans up README.md and adds comprehensive docs.rs documentation to CONTRIBUTING.md.

## Changes

### README.md Fixes

1. **Removed private repo reference** (line 274)
   - Removed: `Originally developed as part of the [Chipp Edge Companion](https://github.com/paulbreuler/chipp-edge-companion) project`
   - This repo is private and should not be referenced

2. **Fixed API examples** (lines 47, 69)
   - Changed `ChippClient::new(config)` to `ChippClient::new(config)?`
   - Reflects the Result-returning API from PR #6

## Testing

- [x] `cargo fmt --check` ✅
- [x] `cargo clippy --all-targets --all-features -- -D warnings` ✅
- [x] `cargo test --lib` ✅ (11 passed)
- [x] `cargo doc --no-deps --all-features` ✅

