### PR TITLE
chore: add workflow_dispatch to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Allows manual triggering of release-please workflow to re-create Release PR with correct prerelease config.

After merge, we can run:
\\\

to create the \ Release PR.