### PR TITLE
fix: add versioning-strategy for alpha prereleases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,9 @@
   "packages": {
     ".": {
       "release-type": "rust",
-      "prerelease": true,
+      "versioning-strategy": "prerelease",
       "prerelease-type": "alpha",
+      "prerelease": true,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [


### PR DESCRIPTION
## Problem

release-please was creating \ instead of \.

## Root Cause

The \ config requires \ to take effect.

From [release-please docs](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#versioning-strategies):

| Versioning Strategy | Description |
|---------------------|-------------|
| \ | Bumping prerelease number (eg. 1.2.0-beta01 to 1.2.0-beta02) or if prerelease type is set, using that in the prerelease part (eg. 1.2.1 to 1.3.0-beta) |

## Fix

Added \ to \.

After merge, close PR #17 and release-please will create a new Release PR for \.