### PR TITLE
fix: force 0.1.0-alpha.1 release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,7 @@
   "packages": {
     ".": {
       "release-type": "rust",
-      "versioning-strategy": "prerelease",
-      "prerelease-type": "alpha",
+      "release-as": "0.1.0-alpha.1",
       "prerelease": true,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
## Problem

release-please prerelease versioning has known issues:

- **[googleapis/release-please#2447](https://github.com/googleapis/release-please/issues/2447)** - `prerelease-type` in manifest is ignored if previous prerelease status was not empty
- **[googleapis/release-please#510](https://github.com/googleapis/release-please/issues/510)** - Original feature request for pre-release support (still has `needs design` label)

From issue #2447:
> *"The TLDR is that it's not really following the semver spec, nor is it even using the semver package to affect semver versioning. This leads to the issue described here, as well as other issues such as not actually being able to leave pre-release mode once you are in it."*
> — [@wraithgar (npm maintainer)](https://github.com/googleapis/release-please/issues/2447#issuecomment-2529175271)

The recommended workaround from the issue:
> *"I've currently been using release-as: to move to the next phase. It works, but it's not automated."*

## Solution

Use `release-as: 0.1.0-alpha.1` to explicitly force the first alpha version.

## After This Release

Remove `release-as` from config. Future alpha bumps may need manual `release-as` updates until googleapis/release-please#2447 is resolved.